### PR TITLE
add security headers and canonical url

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -102,6 +102,24 @@ const moduleExports = {
     hideSourceMaps: true,
   },
   experimental: { images: { allowFutureImage: true } },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value:
+              "frame-ancestors 'none'",
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+        ],
+      },
+    ];
+  },
   async redirects() {
     return [
       ...legacyAPIRedirects,

--- a/pages/index.js
+++ b/pages/index.js
@@ -36,7 +36,7 @@ const Home = ({ locale, onLocale, isMobile, articles, seo, navLinks }) => {
             src="/images/graphics/splines34.svg"
             width={1100}
             height={800}
-            alt="spline"
+            alt="splines"
             priority
           />
         </span>

--- a/src/utils/seo.js
+++ b/src/utils/seo.js
@@ -15,6 +15,10 @@ const formatSeo = (seoRes) => {
     seo.metaViewport = seoRes.metaViewport;
   }
 
+  if (seoRes.canonicalURL) {
+    seo.canonicalURL = seoRes.canonicalURL;
+  }
+
   if (seoRes.metaSocial) {
     const metaSocial = {};
     seoRes.metaSocial.forEach((metaSoc) => {


### PR DESCRIPTION
add headers to prevent iframing, issue #71
allow canonical url to be set in the CMS SEO settings to prevent duplicate url indexing, issue #72